### PR TITLE
Disable Flask reloader in Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,4 +115,4 @@ def obter_previsao():
 if __name__ == '__main__':
     # Use '0.0.0.0' para ser acessível na rede local, se necessário
     # debug=True é útil durante o desenvolvimento, mas desative em produção
-    app.run(debug=True, port=5001) # Usa porta 5001 para evitar conflito com outras apps
+    app.run(debug=True, port=5001, use_reloader=False) # Usa porta 5001 para evitar conflito com outras apps


### PR DESCRIPTION
## Summary
- prevent Flask development server from auto-restarting by disabling the reloader

## Testing
- `python app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b926aca748832b8a06f8534dceb4ff